### PR TITLE
Add check to verify if accumulo was initalized

### DIFF
--- a/ansible/roles/geotrellis.accumulo/tasks/main.yml
+++ b/ansible/roles/geotrellis.accumulo/tasks/main.yml
@@ -35,9 +35,16 @@
         dest="{{ accumulo_conf_dir }}/masters"
         mode=0644
 
+- name: Check if accumulo has been initialized
+  command: "hdfs dfs -test -d /accumulo"
+  register: hdfs_files
+  ignore_errors: yes
+
+
 - name: Initialize Accumulo Leader
   sudo_user: accumulo
   command: "accumulo init --instance-name {{ accumulo_instance_name }} --password {{ accumulo_secret }}"
+  when: "hdfs_files.rc == 1"
 
 - name: Restart Accumulo Server
   service: name={{ item }} enabled=yes state=started


### PR DESCRIPTION
Closes #3 

This commit adds a check to verify whether or not
accumulo has been initialized previously. Initialization
is only required a single time and if re-run with
the same namining schema then accumulo will throw
an exception.
