### PR TITLE
Update roles to most recent versions

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -8,10 +8,6 @@ geotrellis_git_path: /vagrant/geotrellis
 geotrellis_git_branch: master
 geotrellis_git_url: https://github.com/geotrellis/geotrellis.git
 
-spark_version: "1.2.0+cdh5.3.1+365-1.cdh5.3.1.p0.17~trusty-cdh5.3.1"
-
 accumulo_secret: "secret"
 accumulo_leader_host: "localhost"
 accumulo_instance_name: "geotrellis-accumulo-cluster"
-
-java_version: "7u75-2.5.4*"

--- a/ansible/roles.txt
+++ b/ansible/roles.txt
@@ -1,6 +1,6 @@
-azavea.java,0.1.0
+azavea.java,0.2.1
 azavea.git,0.1.0
-azavea.spark,0.1.1
-azavea.zookeeper,0.3.0
+azavea.spark,0.3.0
+azavea.zookeeper,0.4.0
 azavea.accumulo,0.1.0
-azavea.hdfs,0.4.1
+azavea.hdfs,0.5.0

--- a/ansible/roles/geotrellis.hdfs/defaults/main.yml
+++ b/ansible/roles/geotrellis.hdfs/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-hdfs_version: "2.5.0+cdh5.3.*"
+hdfs_version: "2.6.0+cdh5.4.*"
+hdfs_cloudera_distribution: "cdh5.4"
 hdfs_conf_dir: "/etc/hadoop/conf"
 hdfs_namenode: False
 hdfs_namenode_host: localhost

--- a/ansible/roles/geotrellis.hdfs/tasks/main.yml
+++ b/ansible/roles/geotrellis.hdfs/tasks/main.yml
@@ -4,14 +4,14 @@
            state=present
 
 - name: Configure the Cloudera APT repositories
-  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-cdh5 contrib"
+  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-{{ hdfs_cloudera_distribution }} contrib"
                   state=present
 
 - name: Pin Cloudera APT repositories
   template: src=cdh5.j2 dest=/etc/apt/preferences.d/cdh5
 
 - name: Install Hadoop HDFS
-  apt: pkg=hadoop-hdfs=2.5.0+cdh5.3.*
+  apt: pkg=hadoop-hdfs={{ hdfs_version }}
 
 - name: Install Hadoop HDFS NameNode
   apt: pkg=hadoop-hdfs-namenode={{ hdfs_version }}


### PR DESCRIPTION
Closes issue #8

Some of the versions defined in those packages were being
overridden because the role was out of date. Roles have been
updated so those aren't necessary any longer.
